### PR TITLE
Add bindings for source port iteration

### DIFF
--- a/dublintraceroute/__main__.py
+++ b/dublintraceroute/__main__.py
@@ -69,7 +69,13 @@ def parse_args():
             '-b', '--broken-nat', action='store_true',
             default=bool(_dublintraceroute.DEFAULT_BROKEN_NAT),
             help=('The network has a broken NAT (e.g. no payload fixup). Try '
-                  'this if you see less hops than expected '
+                  'this if you see fewer hops than expected '
+                  '(default: %(default)s)')
+        )
+        subparser.add_argument(
+            '-i', '--iterate-sport', action='store_true',
+            default=bool(_dublintraceroute.DEFAULT_USE_SRCPORT_FOR_PATH_GENERATION),
+            help=('Iterate the source port instead of the destination port '
                   '(default: %(default)s)')
         )
 
@@ -121,7 +127,7 @@ def main():
         print('Traceroute to {t}'.format(t=args.target))
         print('  Source port: {s}, destination port: {d}, num paths: {n}, '
               'min TTL: {mint}, max TTL: {maxt}, delay: {delay}, '
-              'broken NAT: {bn}'.format(
+              'broken NAT: {bn}, iterate on src port: {isrc}'.format(
                   s=args.sport,
                   d=args.dport,
                   n=args.npaths,
@@ -129,10 +135,12 @@ def main():
                   maxt=args.max_ttl,
                   delay=args.delay,
                   bn=args.broken_nat,
+                  isrc=args.use_srcport_for_path_generation,
               ))
         dub = DublinTraceroute(args.target, args.sport, args.dport, args.npaths,
                                args.min_ttl, args.max_ttl, args.delay,
-                               args.broken_nat)
+                               args.broken_nat,
+                               args.use_srcport_for_path_generation)
         results = dub.traceroute()
         results.pretty_print()
 

--- a/dublintraceroute/dublintraceroute.py
+++ b/dublintraceroute/dublintraceroute.py
@@ -14,7 +14,8 @@ class DublinTraceroute(_dublintraceroute.DublinTraceroute):
                 'sport={sport!r}, dport={dport!r}, '
                 'npaths={npaths!r}, min_ttl={min_ttl}, '
                 'max_ttl={max_ttl!r}, delay={delay!r}, '
-                'broken_nat={broken_nat!r})>'.format(
+                'broken_nat={broken_nat!r}, '
+                'use_srcport_for_path_generation={use_srcport_for_path_generation!r})>'.format(
                     self=self,
                     target=self.target,
                     sport=self.sport,
@@ -24,6 +25,7 @@ class DublinTraceroute(_dublintraceroute.DublinTraceroute):
                     max_ttl=self.max_ttl,
                     delay=self.delay,
                     broken_nat=self.broken_nat,
+                    use_srcport_for_path_generation=self.use_srcport_for_path_generation,
                     )
                 )
 
@@ -51,7 +53,7 @@ class DublinTraceroute(_dublintraceroute.DublinTraceroute):
 
 
 def probe(target, sport=None, dport=None, npaths=1, ttl=64, delay=None,
-          broken_nat=None):
+          broken_nat=None, use_srcport_for_path_generation=None):
     '''
     Send one or more probes to a specific host, one per path, and return their
     RTT as a list of (target_ip, srcport, dstport, rtt_usec)
@@ -66,8 +68,11 @@ def probe(target, sport=None, dport=None, npaths=1, ttl=64, delay=None,
         delay = _dublintraceroute.DEFAULT_DELAY
     if broken_nat is None:
         broken_nat = _dublintraceroute.DEFAULT_BROKEN_NAT
+    if use_srcport_for_path_generation is None:
+        use_srcport_for_path_generation = _dublintraceroute.DEFAULT_USE_SRCPORT_FOR_PATH_GENERATION
     d = DublinTraceroute(target, sport, dport, npaths, min_ttl=ttl, max_ttl=ttl,
-                         delay=delay, broken_nat=broken_nat)
+                         delay=delay, broken_nat=broken_nat,
+                         use_srcport_for_path_generation=use_srcport_for_path_generation)
     result = d.traceroute()
     ret = []
     for flow_id, flows in result['flows'].items():

--- a/dublintraceroute/py2/_dublintraceroute.cc
+++ b/dublintraceroute/py2/_dublintraceroute.cc
@@ -17,12 +17,14 @@ static PyObject* DublinTraceroute_init(PyObject *self, PyObject *args,
 	unsigned short max_ttl = DublinTraceroute::default_max_ttl;
 	unsigned int delay = DublinTraceroute::default_delay;
 	unsigned int broken_nat = DublinTraceroute::default_broken_nat;
+	unsigned int use_srcport_for_path_generation = DublinTraceroute::default_use_srcport_for_path_generation;
 	static const char *kwlist[] = { "self", "target", "sport", "dport",
-		"npaths", "min_ttl", "max_ttl", "delay", "broken_nat", NULL };
-	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "Os|HHHHHHH",
+		"npaths", "min_ttl", "max_ttl", "delay", "broken_nat",
+		"use_srcport_for_path_generation", NULL };
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "Os|HHHHHHHH",
 				(char **)&kwlist, &self, &target, &sport,
 				&dport, &npaths, &min_ttl, &max_ttl, &delay,
-				&broken_nat)) {
+				&broken_nat, &use_srcport_for_path_generation)) {
 		PyErr_BadArgument();
 		return NULL;
 	}
@@ -39,7 +41,8 @@ static PyObject* DublinTraceroute_init(PyObject *self, PyObject *args,
 			*py_min_ttl = PyString_FromString("min_ttl"),
 			*py_max_ttl = PyString_FromString("max_ttl"),
 			*py_delay = PyString_FromString("delay"),
-			*py_broken_nat = PyString_FromString("broken_nat");
+			*py_broken_nat = PyString_FromString("broken_nat"),
+			*py_use_srcport_for_path_generation = PyUnicode_FromString("use_srcport_for_path_generation");
 
 	Py_INCREF(py_sport);
 	Py_INCREF(py_dport);
@@ -47,6 +50,7 @@ static PyObject* DublinTraceroute_init(PyObject *self, PyObject *args,
 	Py_INCREF(py_npaths);
 	Py_INCREF(py_min_ttl);
 	Py_INCREF(py_max_ttl);
+	Py_INCREF(py_use_srcport_for_path_generation);
 
 	PyObject_SetAttr(self, py_sport, Py_BuildValue("i", sport));
 	PyObject_SetAttr(self, py_dport, Py_BuildValue("i", dport));
@@ -56,6 +60,7 @@ static PyObject* DublinTraceroute_init(PyObject *self, PyObject *args,
 	PyObject_SetAttr(self, py_max_ttl, Py_BuildValue("i", max_ttl));
 	PyObject_SetAttr(self, py_delay, Py_BuildValue("i", delay));
 	PyObject_SetAttr(self, py_broken_nat, PyBool_FromLong(broken_nat));
+	PyObject_SetAttr(self, py_use_srcport_for_path_generation, PyBool_FromLong(use_srcport_for_path_generation));
 
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -85,14 +90,15 @@ static PyMethodDef DublinTracerouteMethods[] =
 		"Initialize DublinTraceroute\n"
 		"\n"
 		"Arguments:\n"
-		"    target     : the target IP address\n"
-		"    srcport    : the source UDP port (optional, default=12345)\n"
-		"    dstport    : the destination UDP port to start with (optional, default=33434)\n"
-		"    npaths     : the number of paths to cover (optional, default=20)\n"
-		"    min_ttl    : the maximum Time-To-Live (optional, default=1)\n"
-		"    max_ttl    : the maximum Time-To-Live (optional, default=30)\n"
-		"    delay      : the inter-packet delay in milliseconds (optional, default=10ms)"
-		"    broken_nat : the network has a broken NAT configuration (e.g. no payload fixup). Try this if you see less hops than expected"
+		"    target                          : the target IP address\n"
+		"    srcport                         : the source UDP port (optional, default=12345)\n"
+		"    dstport                         : the destination UDP port to start with (optional, default=33434)\n"
+		"    npaths                          : the number of paths to cover (optional, default=20)\n"
+		"    min_ttl                         : the maximum Time-To-Live (optional, default=1)\n"
+		"    max_ttl                         : the maximum Time-To-Live (optional, default=30)\n"
+		"    delay                           : the inter-packet delay in milliseconds (optional, default=10ms)"
+		"    broken_nat                      : the network has a broken NAT configuration (e.g. no payload fixup). Try this if you see fewer hops than expected"
+		"    use_srcport_for_path_generation : generate paths using source port instead of destination port"
 		"\n"
 		"Return value:\n"
 		"    a JSON object containing the traceroute data. See example below\n"
@@ -153,6 +159,8 @@ init_dublintraceroute(void)
         PyInt_FromLong(DublinTraceroute::default_delay));
     PyObject_SetAttrString(module, "DEFAULT_BROKEN_NAT",
         PyInt_FromLong(DublinTraceroute::default_broken_nat));
+    PyObject_SetAttrString(module, "DEFAULT_USE_SRCPORT_FOR_PATH_GENERATION",
+        PyLong_FromLong(DublinTraceroute::default_use_srcport_for_path_generation));
 
     /* create the DublinTraceroute class */
     PyObject *classDictDT = PyDict_New();

--- a/tests/test_dublintraceroute.py
+++ b/tests/test_dublintraceroute.py
@@ -27,7 +27,7 @@ def test_str():
     d = dublintraceroute.DublinTraceroute('127.0.0.1', sport=12345,
             dport=33434, npaths=10, min_ttl=3, max_ttl=15, delay=100,
             broken_nat=False)
-    assert str(d) == '''<DublinTraceroute (target='127.0.0.1', sport=12345, dport=33434, npaths=10, min_ttl=3, max_ttl=15, delay=100, broken_nat=False)>'''
+    assert str(d) == '''<DublinTraceroute (target='127.0.0.1', sport=12345, dport=33434, npaths=10, min_ttl=3, max_ttl=15, delay=100, broken_nat=False, use_srcport_for_path_generation=False)>'''
 
 
 class MockDublinTraceroute(object):


### PR DESCRIPTION
The C++ library supports iterating on source port for path generation,
this patch exposes the functionality in the Python bindings.

This is a remake of
https://github.com/insomniacslk/python-dublin-traceroute/pull/12 .

Signed-off-by: Andrea Barberio <insomniac@slackware.it>