### PR TITLE
Draw both source and dest ports

### DIFF
--- a/dublintraceroute/dublintraceroute.py
+++ b/dublintraceroute/dublintraceroute.py
@@ -182,7 +182,8 @@ def to_graphviz(traceroute, no_rtt=False):
             else:
                 next_nodename = next_received['ip']['src']
             if index == 0:
-                edgeattrs['label'] = 'dport\n{dp}'.format(dp=flow)
+                u = nexthop['sent']['udp']
+                edgeattrs['label'] = 'srcport {sp}\ndstport {dp}'.format(sp=u['sport'], dp=u['dport'])
             rtt = nexthop['rtt_usec']
             try:
                 if previous_nat_id != nexthop['nat_id']:


### PR DESCRIPTION
Both ports are more useful. This also helps when a traceroute iterated
over source ports instead of assuming that the iterated port is always
the destination one.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>