### PR TITLE
Handle C++ exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 .eggs/
 dublintraceroute.egg-info/
 dublintraceroute/_dublintraceroute.so
+.venv/
+.vscode/

--- a/dublintraceroute/py3/_dublintraceroute.cc
+++ b/dublintraceroute/py3/_dublintraceroute.cc
@@ -99,6 +99,12 @@ static PyObject* DublinTraceroute_traceroute(PyObject *self, PyObject *args)
 	std::shared_ptr<TracerouteResults> results;
 	try {
 		results = dublintraceroute->traceroute();
+	} catch (Tins::malformed_packet &e) {
+		PyErr_SetString(PyExc_RuntimeError, e.what());
+		return NULL;
+	} catch (std::runtime_error &e) {
+		PyErr_SetString(PyExc_RuntimeError, e.what());
+		return NULL;
 	} catch (DublinTracerouteException &e) {
 		PyErr_SetString(PyExc_RuntimeError, e.what());
 		return NULL;


### PR DESCRIPTION
This PR catches more underlying C++ exceptions and handles them to prevent python from crashing when encountering one.

Currently, the following exceptions are caught:

- `std::runtime_error` (e.g. when running without permissions)
- `Tins::malformed_packet`

Fixes #21 and #10 (at least partially)